### PR TITLE
fix(mlpca): correct PC orientation and component count for truncated PCA

### DIFF
--- a/src/sillywalk/_mlpca.py
+++ b/src/sillywalk/_mlpca.py
@@ -96,7 +96,11 @@ class PCAPredictor:
         )
         self.pca_low_variance_columns = set(self.columns).difference(self.pca_columns)
 
-        self.pca_n_components = len(self.pca_columns)
+        # Number of retained principal components, not number of input features.
+        # pca_eigenvectors has shape (n_components, n_features).
+        self.pca_n_components = (
+            self.pca_eigenvectors.shape[0] if self.pca_eigenvectors.size else 0
+        )
         self._pca_means = np.array(
             [self.means[self.columns.index(col)] for col in self.pca_columns]
         )
@@ -340,7 +344,9 @@ class PCAPredictor:
                 float(param[col]) - float(self._pca_means[i])
             ) / float(self._pca_stds[i])
 
-        pcs = np.dot(self.pca_eigenvectors.T, normalized_params)
+        # pca_eigenvectors has shape (n_components, n_features); project
+        # standardized features onto principal components.
+        pcs = np.dot(self.pca_eigenvectors, normalized_params)
         return pcs.tolist()
 
     def components_to_parameters(
@@ -356,8 +362,10 @@ class PCAPredictor:
                 f"Wrong number of pca modes. System has {self.pca_n_components} modes. "
             )
 
+        # pca_eigenvectors has shape (n_components, n_features); reconstruct
+        # standardized features from principal-component coordinates.
         reduced_params = (
-            self.pca_eigenvectors @ principal_components
+            self.pca_eigenvectors.T @ principal_components
         ) * self._pca_stds + self._pca_means
         full_params = dict(zip(self.columns, self.means.tolist()))
         for col, val in zip(self.pca_columns, reduced_params.tolist()):

--- a/tests/test_mlpca.py
+++ b/tests/test_mlpca.py
@@ -150,14 +150,6 @@ def make_truncatable_dataset(n=200, seed=1):
     return pd.DataFrame({"a": a, "b": b, "c": c})
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Bug: parameters_to_components projects with pca_eigenvectors.T "
-        "instead of pca_eigenvectors, which only works when no components "
-        "are dropped. With a truncated PCA the shapes do not align."
-    ),
-)
 def test_parameters_to_components_works_with_truncated_pca():
     df = make_truncatable_dataset()
     model = PCAPredictor(df, n_components=1)
@@ -174,16 +166,6 @@ def test_parameters_to_components_works_with_truncated_pca():
     assert len(pcs) == 1
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Bug: components_to_parameters reconstructs with pca_eigenvectors @ pcs "
-        "instead of pca_eigenvectors.T @ pcs. Combined with pca_n_components "
-        "being set to len(pca_columns) instead of the number of retained "
-        "components, callers cannot supply a correctly-sized PC vector when "
-        "the PCA is truncated."
-    ),
-)
 def test_components_to_parameters_accepts_retained_pc_count():
     df = make_truncatable_dataset()
     model = PCAPredictor(df, n_components=1)
@@ -199,14 +181,6 @@ def test_components_to_parameters_accepts_retained_pc_count():
         assert np.isfinite(out[col])
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Bug: pca_n_components is initialised from len(pca_columns), i.e. the "
-        "number of input features, rather than from the number of retained "
-        "components (pca_eigenvectors.shape[0])."
-    ),
-)
 def test_pca_n_components_reflects_retained_components():
     df = make_truncatable_dataset()
     model = PCAPredictor(df, n_components=1)


### PR DESCRIPTION
PCAPredictor stored sklearn's PCA.components_ in pca_eigenvectors with
shape (n_components, n_features), but two helpers used the wrong
orientation and pca_n_components was tied to the input feature count.
The bugs only surfaced when fewer components were retained than input
features (e.g. with the default n_components=0.99 on correlated data).

- parameters_to_components: project with pca_eigenvectors @ x instead
  of pca_eigenvectors.T @ x, matching sklearn's convention and the
  reconstruction already used in predict().
- components_to_parameters: reconstruct standardized features with
  pca_eigenvectors.T @ pcs instead of pca_eigenvectors @ pcs.
- pca_n_components: derive from pca_eigenvectors.shape[0] (retained
  components) instead of len(pca_columns) (input feature count). This
  is also what components_to_parameters validates against, so callers
  can now supply correctly-sized PC vectors after truncation.

Removes the xfail markers on the three regression tests added in the
previous commit.