### PR TITLE
fix(mlpca): detect infeasible collinear constraints instead of siletly dropping

### DIFF
--- a/src/sillywalk/_mlpca.py
+++ b/src/sillywalk/_mlpca.py
@@ -216,24 +216,55 @@ class PCAPredictor:
     def _drop_parallel_constraints(
         self, B: NDArray, d: dict[str, float]
     ) -> tuple[NDArray, dict[str, float]]:
-        """Drop linearly dependent constraints (parallel or anti-parallel rows).
+        """Drop redundant collinear constraints, raising on infeasible pairs.
 
-        Rows i and j are considered collinear if |cos(theta)| ~ 1, i.e.
-        |<b_i, b_j>| ≈ ||b_i||·||b_j||.
+        Rows i and j of B are collinear when ``|cos(theta)| ~ 1``. For two
+        collinear rows the second is redundant only if its right-hand side
+        is consistent with the first, i.e. ``d_j ≈ alpha * d_i`` where
+        ``alpha = <b_i, b_j> / ||b_i||^2`` is the scalar that maps ``b_i``
+        onto ``b_j``. When the values disagree the constraint system is
+        infeasible and silently dropping a row would let ``predict`` return
+        a result that satisfies one constraint while ignoring the other.
         """
+        keys = list(d)
+        cos_tol = 1e-7
+        # Relative tolerance on RHS consistency, scaled by the magnitude of
+        # the values involved so the check works for both small and large d.
+        rhs_rtol = 1e-7
+        rhs_atol = 1e-9
+
         drop: list[str] = []
         for i in range(B.shape[0]):
+            if keys[i] in drop:
+                continue
+            norm_i = float(np.linalg.norm(B[i]))
+            if norm_i == 0:
+                continue
             for j in range(i + 1, B.shape[0]):
-                inner_product = np.inner(B[i], B[j])
-                norm_i = np.linalg.norm(B[i])
-                norm_j = np.linalg.norm(B[j])
-                if norm_i == 0 or norm_j == 0:
+                if keys[j] in drop:
                     continue
-                # Detect both parallel and anti-parallel vectors
-                if abs(abs(inner_product) - (norm_j * norm_i)) < 1e-7:
-                    drop.append(list(d)[j])
-        drop = list(set(drop))
-        drop_indices = [list(d).index(key) for key in drop]
+                norm_j = float(np.linalg.norm(B[j]))
+                if norm_j == 0:
+                    continue
+                inner_product = float(np.inner(B[i], B[j]))
+                # Cosine-based collinearity check (works at any magnitude).
+                if abs(abs(inner_product) / (norm_i * norm_j) - 1.0) >= cos_tol:
+                    continue
+                # b_j = alpha * b_i; check d_j ?= alpha * d_i.
+                alpha = inner_product / (norm_i * norm_i)
+                expected = alpha * d[keys[i]]
+                actual = d[keys[j]]
+                if not np.isclose(actual, expected, rtol=rhs_rtol, atol=rhs_atol):
+                    raise ValueError(
+                        "Inconsistent constraints: "
+                        f"'{keys[i]}' and '{keys[j]}' are collinear in "
+                        "principal-component space but their values are "
+                        "incompatible "
+                        f"(expected {keys[j]} ≈ {expected:g}, got {actual:g})."
+                    )
+                drop.append(keys[j])
+
+        drop_indices = [keys.index(key) for key in drop]
         B_new = np.delete(B, drop_indices, axis=0) if drop_indices else B
         d_new = {k: v for k, v in d.items() if k not in drop}
         return B_new, d_new

--- a/tests/test_mlpca.py
+++ b/tests/test_mlpca.py
@@ -187,17 +187,7 @@ def test_pca_n_components_reflects_retained_components():
     assert model.pca_n_components == 1
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Bug: _drop_parallel_constraints removes parallel rows without "
-        "checking whether the corresponding right-hand-side values are "
-        "consistent. Infeasible constraints are silently dropped instead of "
-        "being reported, so predict() satisfies one constraint exactly and "
-        "ignores the conflicting one."
-    ),
-)
-def test_inconsistent_parallel_constraints_not_silently_dropped():
+def test_inconsistent_parallel_constraints_raise():
     # With n_components=1 every row of B is a scalar, so any two constraints
     # on different PCA columns are 'parallel'. Choose values that imply
     # incompatible positions on the single principal component.
@@ -211,11 +201,5 @@ def test_inconsistent_parallel_constraints_not_silently_dropped():
     # mean while b is below its mean is infeasible on the single PC.
     constraints = {"a": a_mean + 1.0, "b": b_mean - 1.0}
 
-    pred = model.predict(constraints)
-
-    # A correct implementation should either raise, warn, or return a
-    # least-squares compromise that satisfies neither constraint exactly.
-    a_satisfied = np.isclose(pred["a"], constraints["a"], atol=1e-6)
-    b_satisfied = np.isclose(pred["b"], constraints["b"], atol=1e-6)
-    assert not (a_satisfied and not b_satisfied)
-    assert not (b_satisfied and not a_satisfied)
+    with pytest.raises(ValueError, match="[Ii]nconsistent"):
+        model.predict(constraints)


### PR DESCRIPTION
_drop_parallel_constraints removed redundant collinear rows without checking that their right-hand sides agreed. When a user supplied two constraints whose projections onto the principal-component basis were parallel but with incompatible values, the second constraint was silently discarded and predict() returned a result that satisfied one constraint exactly while ignoring the other.

The function now, for each collinear pair, computes the scalar alpha that maps b_i onto b_j and verifies d_j ≈ alpha * d_i. If the values are consistent the redundant row is dropped as before; otherwise a ValueError is raised naming both constraints. The collinearity check itself is also tightened to a relative cosine tolerance so it behaves consistently regardless of vector magnitude.

This removes the final xfail on the regression test.