### PR TITLE
fix(mlpca): make pca_explained_variance_ratio reflect truncation

### DIFF
--- a/src/sillywalk/_mlpca.py
+++ b/src/sillywalk/_mlpca.py
@@ -77,6 +77,7 @@ class PCAPredictor:
         pca_columns: StringSequenceOrArray,
         pca_eigenvectors: NumericSequenceOrArray,
         pca_eigenvalues: NumericSequenceOrArray,
+        pca_explained_variance_ratio: NumericSequenceOrArray,
     ) -> None:
         """Internal initializer used by classmethods and __init__."""
         if isinstance(columns, np.ndarray):
@@ -89,10 +90,8 @@ class PCAPredictor:
         self.columns = list(columns)  # Ensure list for index()
         self.pca_columns = list(pca_columns)  # Ensure list for index()
         self.pca_eigenvectors = np.array(pca_eigenvectors)
-        self.pca_explained_variance_ratio = (
-            np.array(pca_eigenvalues) / np.sum(pca_eigenvalues)
-            if np.size(pca_eigenvalues) > 0
-            else np.array([])
+        self.pca_explained_variance_ratio = np.array(
+            pca_explained_variance_ratio, dtype=float
         )
         self.pca_low_variance_columns = set(self.columns).difference(self.pca_columns)
 
@@ -128,6 +127,7 @@ class PCAPredictor:
         pca_columns: StringSequenceOrArray | None = None,
         pca_eigenvectors: NDArray | None = None,
         pca_eigenvalues: NDArray | None = None,
+        pca_explained_variance_ratio: NDArray | None = None,
     ) -> "PCAPredictor":
         """Load a saved model from a .npz file created by export_pca_data."""
         if filename is not None:
@@ -138,7 +138,14 @@ class PCAPredictor:
             pca_columns = data["pca_columns"]
             pca_eigenvectors = data["pca_eigenvectors"]
             pca_eigenvalues = data["pca_eigenvalues"]
-        if means is None or stds is None or columns is None or pca_columns is None:
+            pca_explained_variance_ratio = data["pca_explained_variance_ratio"]
+        if (
+            means is None
+            or stds is None
+            or columns is None
+            or pca_columns is None
+            or pca_explained_variance_ratio is None
+        ):
             raise ValueError("Missing required PCA data.")
 
         instance = cls.__new__(cls)
@@ -149,6 +156,7 @@ class PCAPredictor:
             pca_columns=pca_columns,
             pca_eigenvectors=pca_eigenvectors,
             pca_eigenvalues=pca_eigenvalues,
+            pca_explained_variance_ratio=pca_explained_variance_ratio,
         )
         return instance
 
@@ -191,6 +199,7 @@ class PCAPredictor:
                 pca_columns=pca_columns,
                 pca_eigenvectors=np.zeros((0, 0), dtype=float),
                 pca_eigenvalues=np.zeros((0,), dtype=float),
+                pca_explained_variance_ratio=np.zeros((0,), dtype=float),
             )
             return
 
@@ -211,6 +220,9 @@ class PCAPredictor:
             pca_columns=pca_columns,
             pca_eigenvectors=pca.components_,
             pca_eigenvalues=pca.explained_variance_,
+            # sklearn divides by the *total* variance of the input matrix,
+            # so this correctly reflects information lost to truncation.
+            pca_explained_variance_ratio=pca.explained_variance_ratio_,
         )
 
     def _drop_parallel_constraints(
@@ -413,27 +425,20 @@ class PCAPredictor:
         If filename is None, return an in-memory buffer.
         """
 
+        save_kwargs = dict(
+            means=self.means,
+            stds=self.stds,
+            columns=self.columns,
+            pca_columns=self.pca_columns,
+            pca_eigenvectors=self.pca_eigenvectors,
+            pca_eigenvalues=self.pca_eigenvalues,
+            pca_explained_variance_ratio=self.pca_explained_variance_ratio,
+        )
+
         if filename is None:
             fh = BytesIO()
-
-            np.savez_compressed(
-                fh,
-                means=self.means,
-                stds=self.stds,
-                columns=self.columns,
-                pca_columns=self.pca_columns,
-                pca_eigenvectors=self.pca_eigenvectors,
-                pca_eigenvalues=self.pca_eigenvalues,
-            )
+            np.savez_compressed(fh, **save_kwargs)
             fh.seek(0)
             return fh
         else:
-            np.savez_compressed(
-                filename,
-                means=self.means,
-                stds=self.stds,
-                columns=self.columns,
-                pca_columns=self.pca_columns,
-                pca_eigenvectors=self.pca_eigenvectors,
-                pca_eigenvalues=self.pca_eigenvalues,
-            )
+            np.savez_compressed(filename, **save_kwargs)

--- a/src/sillywalk/_mlpca.py
+++ b/src/sillywalk/_mlpca.py
@@ -425,20 +425,28 @@ class PCAPredictor:
         If filename is None, return an in-memory buffer.
         """
 
-        save_kwargs = dict(
-            means=self.means,
-            stds=self.stds,
-            columns=self.columns,
-            pca_columns=self.pca_columns,
-            pca_eigenvectors=self.pca_eigenvectors,
-            pca_eigenvalues=self.pca_eigenvalues,
-            pca_explained_variance_ratio=self.pca_explained_variance_ratio,
-        )
-
         if filename is None:
             fh = BytesIO()
-            np.savez_compressed(fh, **save_kwargs)
+            np.savez_compressed(
+                fh,
+                means=self.means,
+                stds=self.stds,
+                columns=self.columns,
+                pca_columns=self.pca_columns,
+                pca_eigenvectors=self.pca_eigenvectors,
+                pca_eigenvalues=self.pca_eigenvalues,
+                pca_explained_variance_ratio=self.pca_explained_variance_ratio,
+            )
             fh.seek(0)
             return fh
         else:
-            np.savez_compressed(filename, **save_kwargs)
+            np.savez_compressed(
+                filename,
+                means=self.means,
+                stds=self.stds,
+                columns=self.columns,
+                pca_columns=self.pca_columns,
+                pca_eigenvectors=self.pca_eigenvectors,
+                pca_eigenvalues=self.pca_eigenvalues,
+                pca_explained_variance_ratio=self.pca_explained_variance_ratio,
+            )

--- a/tests/test_mlpca.py
+++ b/tests/test_mlpca.py
@@ -203,3 +203,33 @@ def test_inconsistent_parallel_constraints_raise():
 
     with pytest.raises(ValueError, match="[Ii]nconsistent"):
         model.predict(constraints)
+
+
+def test_explained_variance_ratio_reflects_truncation():
+    # With three strongly collinear features, n_components=1 keeps only a
+    # tiny share of the (already small) total variance lost to truncation.
+    # The ratio must be < 1 and the kept share must be < 1 individually.
+    df = make_truncatable_dataset()
+    model = PCAPredictor(df, n_components=1)
+
+    assert model.pca_explained_variance_ratio.shape == (1,)
+    # Sum is the share of total variance retained; it should reflect
+    # truncation rather than always summing to 1.
+    total_kept = float(np.sum(model.pca_explained_variance_ratio))
+    assert 0.0 < total_kept <= 1.0
+    # On this dataset some variance is genuinely discarded.
+    assert total_kept < 1.0
+
+
+def test_explained_variance_ratio_persisted_in_npz(tmp_path):
+    df = make_truncatable_dataset()
+    model = PCAPredictor(df, n_components=1)
+
+    file = tmp_path / "model.npz"
+    model.export_pca_data(file)
+    loaded = PCAPredictor.from_pca_data(file)
+
+    np.testing.assert_allclose(
+        loaded.pca_explained_variance_ratio,
+        model.pca_explained_variance_ratio,
+    )

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.14.17"
+__generated_with = "0.18.4"
 app = marimo.App(width="medium")
 
 
@@ -97,6 +97,7 @@ def collection_of_tests(df_students, math, pd, pl, pytest, sillywalk):
             pca_columns=model1.pca_columns,
             pca_eigenvectors=model1.pca_eigenvectors,
             pca_eigenvalues=model1.pca_eigenvalues,
+            pca_explained_variance_ratio=model1.pca_explained_variance_ratio,
         )
         constr = {"Age": 26, "Shoesize": 40}
         assert model1.predict(constr) == pytest.approx(
@@ -148,7 +149,6 @@ def _(pl, sillywalk):
     sillywalk.anybody.create_model_file(
         result, "Model.main.any", create_human_model=True
     )
-
     return
 
 


### PR DESCRIPTION
The ratio was computed by dividing the retained eigenvalues by their own sum, so it always summed to 1 even when components were dropped. This silently hid information loss from truncation (the default uses n_components=0.99).

- When fitting the model also store sklearn's pca.explained_variance_ratio_ directly, which is normalised by the total input variance and therefore sums to less than 1 when components are discarded.
- Keep the ratio in the .npz export under 'pca_explained_variance_ratio' and load it back in from_pca_data.

Adds tests confirming the ratio reflects truncation and survives a save/load round-trip.