### PR TITLE
fix(mlpca): floor tiny PCA eigenvalues and clarify component-count name

### DIFF
--- a/src/sillywalk/_mlpca.py
+++ b/src/sillywalk/_mlpca.py
@@ -338,25 +338,41 @@ class PCAPredictor:
 
         B, d = self._drop_parallel_constraints(B, d)
         p = B.shape[0]
-        m = self.pca_eigenvectors.T.shape[1] if self.pca_eigenvectors.size else 0
+        # Number of retained principal components (= columns of B).
+        n_components = self.pca_n_components
 
-        if m == 0:
+        if n_components == 0:
             # No PCA features: return means
             return dict(zip(self.columns, self.means.tolist()))
 
         if target_pcs is None:
-            target_pcs = np.zeros(m)
+            target_pcs = np.zeros(n_components)
 
-        rhs = np.zeros(m + p)
-        rhs[m:] = np.array(list(d.values())) - (B @ target_pcs)
+        # Guard against zero or numerically tiny eigenvalues: the KKT system
+        # uses 1/lambda as a prior weight on each component, which would
+        # otherwise produce inf/NaN and silently invalidate the solve. Floor
+        # at a small fraction of the largest eigenvalue.
+        eig = np.asarray(self.pca_eigenvalues, dtype=float)
+        eig_floor = max(np.max(eig) * 1e-12, np.finfo(float).tiny) if eig.size else 0.0
+        if np.any(eig <= eig_floor):
+            warn(
+                "Some retained PCA eigenvalues are zero or numerically tiny; "
+                "flooring them for the KKT solve. This usually indicates "
+                "redundant or degenerate input features.",
+                stacklevel=2,
+            )
+            eig = np.maximum(eig, eig_floor)
 
-        K = np.zeros((m + p, m + p))
-        K[range(m), range(m)] = 1.0 / self.pca_eigenvalues
-        K[:m, m:] = B.T
-        K[m:, :m] = B
+        rhs = np.zeros(n_components + p)
+        rhs[n_components:] = np.array(list(d.values())) - (B @ target_pcs)
+
+        K = np.zeros((n_components + p, n_components + p))
+        K[range(n_components), range(n_components)] = 1.0 / eig
+        K[:n_components, n_components:] = B.T
+        K[n_components:, :n_components] = B
 
         sol, *_ = np.linalg.lstsq(K, rhs, rcond=None)
-        y_opt = sol[:m] + target_pcs  # Bias by target PCs
+        y_opt = sol[:n_components] + target_pcs  # Bias by target PCs
 
         x_hat_standardized = self.pca_eigenvectors.T @ y_opt
         x_hat_original = x_hat_standardized * self._pca_stds + self._pca_means

--- a/tests/test_mlpca.py
+++ b/tests/test_mlpca.py
@@ -233,3 +233,21 @@ def test_explained_variance_ratio_persisted_in_npz(tmp_path):
         loaded.pca_explained_variance_ratio,
         model.pca_explained_variance_ratio,
     )
+
+
+def test_predict_handles_zero_eigenvalue_without_nan():
+    # Force a zero eigenvalue by mutating the fitted model. predict() must
+    # not divide by zero; it should warn and still return finite values.
+    df = make_truncatable_dataset()
+    model = PCAPredictor(df, n_components=2)
+    assert model.pca_n_components >= 2
+
+    model.pca_eigenvalues = model.pca_eigenvalues.copy()
+    model.pca_eigenvalues[-1] = 0.0
+
+    a_mean = float(model._pca_means[model._pca_column_idx("a")])
+    with pytest.warns(UserWarning, match="tiny"):
+        pred = model.predict({"a": a_mean + 0.1})
+
+    for v in pred.values():
+        assert np.isfinite(v)


### PR DESCRIPTION
predict() builds a KKT system where the diagonal prior weights are
1 / lambda for each retained eigenvalue. Zero or numerically tiny
eigenvalues, easily produced by redundant or degenerate input
features, caused inf/NaN entries that lstsq silently propagated into
the solution.

- Floor eigenvalues at max(eig) * 1e-12. before forming K, and
  warn when any value was actually clamped so
  the underlying data issue is visible.
- Rename the local variable m (which was the retained component
  count, but read as 'feature count' in context) to n_components
  and source it from the new pca_n_components attribute.
